### PR TITLE
Add --rrr and --unrrr to bfoperate

### DIFF
--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -371,18 +371,14 @@ void BFOperateCommand::op_unrrr()
 	// TODO: what if the input bloom filter contains more than 1 bit vectors?
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
-	cout << "loading bloom filter \"" << bfFilenames[0] << "\"" << endl;
 
 	BitVector* bv = bf->bvs[0];
-
 	RrrBitVector* rrrBv = (RrrBitVector*) bv;
 	u64 numBits = rrrBv->num_bits();
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
-	cout << "init new bloom filter \"" << outputFilename << "\"" << endl;
 	dstBf->bvs[0] = BitVector::bit_vector(bvcomp_uncompressed,numBits);
 
-	cout << "decompressing RRR vector into the new bloom filter" << endl;
 	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits);
 	dstBf->save();
 

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -380,12 +380,10 @@ void BFOperateCommand::op_unrrr()
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
 	cout << "init new bloom filter \"" << outputFilename << "\"" << endl;
-	BitVector* dstBv = dstBf->bvs[0];
-
-	dstBv->new_bits (numBits);
+	dstBf->bvs[0] = BitVector::bit_vector(bvcomp_uncompressed,numBits);
 
 	cout << "decompressing RRR vector into the new bloom filter" << endl;
-	decompress_rrr(rrrBv->rrrBits, dstBv->bits->data(), numBits);
+	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits);
 	dstBf->save();
 
 	delete bf;

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -371,14 +371,15 @@ void BFOperateCommand::op_unrrr()
 	// TODO: what if the input bloom filter contains more than 1 bit vectors?
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
-	RrrBitVector* rrrBv = new RrrBitVector (bf->bvs[0]);
-
+	BitVector* bv = bf->bvs[0];
+	
+	RrrBitVector* rrrBv = (RrrBitVector*) bv;
 	u64 numBits = rrrBv->num_bits();
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
 	dstBf->bvs[0]->new_bits (numBits);
 
-	decompress_rrr (rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits);
+	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits)
 	dstBf->save();
 
 	delete bf;

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -374,7 +374,7 @@ void BFOperateCommand::op_unrrr()
 	BitVector* bv = bf->bvs[0];
 	
 	RrrBitVector* rrrBv = (RrrBitVector*) bv;
-	u64 numBits = rrrBv->num_bits();
+	u64 numBits = bf->num_bits();
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
 	dstBf->bvs[0]->new_bits (numBits);

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -379,7 +379,7 @@ void BFOperateCommand::op_unrrr()
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
 	dstBf->bvs[0]->new_bits (numBits);
 
-	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits)
+	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits);
 	dstBf->save();
 
 	delete bf;

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -371,16 +371,20 @@ void BFOperateCommand::op_unrrr()
 	// TODO: what if the input bloom filter contains more than 1 bit vectors?
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
+	cout << "loading bloom filter \"" << bfFilenames[0] << "\"" << endl;
+
 	BitVector* bv = bf->bvs[0];
 
 	RrrBitVector* rrrBv = (RrrBitVector*) bv;
 	u64 numBits = rrrBv->num_bits();
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
+	cout << "init new bloom filter \"" << outputFilename << "\"" << endl;
 	BitVector* dstBv = dstBf->bvs[0];
 
 	dstBv->new_bits (numBits);
 
+	cout << "decompressing RRR vector into the new bloom filter" << endl;
 	decompress_rrr(rrrBv->rrrBits, dstBv->bits->data(), numBits);
 	dstBf->save();
 

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -371,7 +371,7 @@ void BFOperateCommand::op_unrrr()
 	// TODO: what if the input bloom filter contains more than 1 bit vectors?
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
-	RrrBitVector* rrrBv = new RRRBitVector (bf->bvs[0]);
+	RrrBitVector* rrrBv = new RrrBitVector (bf->bvs[0]);
 
 	u64 numBits = rrrBv->num_bits();
 

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -371,7 +371,7 @@ void BFOperateCommand::op_unrrr()
 	// TODO: what if the input bloom filter contains more than 1 bit vectors?
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
-	RrrBitVector* rrrBv = bf->bvs[0];
+	RrrBitVector* rrrBv = new RRRBitVector (bf->bvs[0]);
 
 	u64 numBits = rrrBv->num_bits();
 

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -372,14 +372,16 @@ void BFOperateCommand::op_unrrr()
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
 	BitVector* bv = bf->bvs[0];
-	
+
 	RrrBitVector* rrrBv = (RrrBitVector*) bv;
-	u64 numBits = bf->num_bits();
+	u64 numBits = rrrBv->num_bits();
 
 	BloomFilter* dstBf = BloomFilter::bloom_filter(bf,outputFilename);
-	dstBf->bvs[0]->new_bits (numBits);
+	BitVector* dstBv = dstBf->bvs[0];
 
-	decompress_rrr(rrrBv->rrrBits, dstBf->bvs[0]->bits->data(), numBits);
+	dstBv->new_bits (numBits);
+
+	decompress_rrr(rrrBv->rrrBits, dstBv->bits->data(), numBits);
 	dstBf->save();
 
 	delete bf;

--- a/cmd_bf_operate.cc
+++ b/cmd_bf_operate.cc
@@ -351,7 +351,7 @@ void BFOperateCommand::op_complement()
 
 void BFOperateCommand::op_rrr()
 	{
-	// TODO: what if the input bloom filter contains more than 1 bit vectors?
+	// $$$ MULTI_VECTOR what if the filter contains more than one bit vector!
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
 	BitVector* bv = bf->bvs[0];
@@ -368,7 +368,7 @@ void BFOperateCommand::op_rrr()
 
 void BFOperateCommand::op_unrrr()
 	{
-	// TODO: what if the input bloom filter contains more than 1 bit vectors?
+	// $$$ MULTI_VECTOR what if the filter contains more than one bit vector!
 	BloomFilter* bf = BloomFilter::bloom_filter(bfFilenames[0]);
 	bf->load();
 

--- a/cmd_bf_operate.h
+++ b/cmd_bf_operate.h
@@ -23,6 +23,8 @@ public:
 	virtual void op_xor (void);
 	virtual void op_eq (void);
 	virtual void op_complement (void);
+	virtual void op_rrr (void);
+	virtual void op_unrrr (void);
 
 	std::vector<std::string> bfFilenames;
 	std::string outputFilename;


### PR DESCRIPTION
Add `--rrr` and `--unrrr` to the set of `bfoperate` options.

Despite RRR compressed bloom filter files can be built with the `makebf` command, there is currently no way to convert an RRR compressed bloom filter to the uncompressed version.

With this PR, it should be easy to pass from the RRR compressed to the uncompressed representation of a bloom filter file and vice versa.