### PR TITLE
Add --count to bfoperate and bvoperate

### DIFF
--- a/bit_vector.cc
+++ b/bit_vector.cc
@@ -242,33 +242,36 @@ void BitVector::serialized_in
 
 void BitVector::save()
 	{
-	wall_time_ty startTime;
-
-	if (reportSave)
-		cerr << "Saving " << filename << endl;
-
-	if (bits == nullptr)
-		fatal ("internal error for " + identity()
-		     + "; attempt to save null bit vector");
-
-	if (offset != 0)
-		fatal ("internal error for " + identity()
-		     + "; attempt to save bit vector to non-zero file offset");
-
-	if (reportSaveTime || reportTotalSaveTime) startTime = get_wall_time();
-	std::ofstream out (filename, std::ios::binary | std::ios::trunc | std::ios::out);
-	if (not out)
-		fatal ("error: " + class_identity() + "::save(" + identity() + ")"
-		     + " failed to open \"" + filename + "\"");
-	serialized_out (out);
-	out.close();
-	if (reportSaveTime || reportTotalSaveTime)
+	if (!filename.empty())
 		{
-		double elapsedTime = elapsed_wall_time(startTime);
-		if (reportSaveTime)
-			cerr << "[" + class_identity() + " save] " << std::setprecision(6) << std::fixed << elapsedTime << " secs " << filename << "@" << offset << endl;
-		if (reportTotalSaveTime)
-			totalSaveTime += elapsedTime;  // $$$ danger of precision error?
+		wall_time_ty startTime;
+
+		if (reportSave)
+			cerr << "Saving " << filename << endl;
+
+		if (bits == nullptr)
+			fatal ("internal error for " + identity()
+				+ "; attempt to save null bit vector");
+
+		if (offset != 0)
+			fatal ("internal error for " + identity()
+				+ "; attempt to save bit vector to non-zero file offset");
+
+		if (reportSaveTime || reportTotalSaveTime) startTime = get_wall_time();
+		std::ofstream out (filename, std::ios::binary | std::ios::trunc | std::ios::out);
+		if (not out)
+			fatal ("error: " + class_identity() + "::save(" + identity() + ")"
+				+ " failed to open \"" + filename + "\"");
+		serialized_out (out);
+		out.close();
+		if (reportSaveTime || reportTotalSaveTime)
+			{
+			double elapsedTime = elapsed_wall_time(startTime);
+			if (reportSaveTime)
+				cerr << "[" + class_identity() + " save] " << std::setprecision(6) << std::fixed << elapsedTime << " secs " << filename << "@" << offset << endl;
+			if (reportTotalSaveTime)
+				totalSaveTime += elapsedTime;  // $$$ danger of precision error?
+			}
 		}
 	}
 


### PR DESCRIPTION
First attempt to add the `--count` parameter to the `bvoperate` and `bfoperate` secondary commands.

It is used in conjunction with the already implemented parameters (`--and`, `--or`, `--xor`, etc.) in `bvoperate` and allows to count the number of active bits in the resulting bitvector (BV), as well as the number of active bits in the bitvector of the resulting bloom filter (BF) in the case of the `bfoperate` command.

The idea is to also make the generation of the output BF or BV optional.

The output is reported to the stdout.

--

**Simple use scenario:** I have two BF representations of two genomes and I want to count the number of kmers in common between them.

This can be easily addressed by generating a BF whose BV is the result of the bitwise AND between the two input BFs' BVs, and count the number of active bits. But I do not necessarily want to save the new BF resulting from the AND operation. I just want to know how many bits are set to `1`. This is why the generation of the output bloom filter should be optional.

Of course this works in case both the BFs have been constructed with the same hash function (and only one hash function), so it probably requires some additional check on these two factors.

--

I didn't test the code yet. 
@rsharris it would be awesome if you could have a look at this and give me some feedback.
In the meanwhile, wish you a very happy new year! :tada: