### PR TITLE
Fix typing in simple_bf_size_estimate.py

### DIFF
--- a/scripts/simple_bf_size_estimate.py
+++ b/scripts/simple_bf_size_estimate.py
@@ -65,7 +65,7 @@ def main():
 	if (numHashFuncs == 1):
 		numBits = -distinctKmers/log(1-fpRate)
 	else:
-		numBits = -(numHashFuncs*distinctKmers) / log(1-(fpRate)**(1/numHashFuncs))
+		numBits = -(numHashFuncs*distinctKmers) / log(1-(fpRate)**(1/float(numHashFuncs)))
 	numBits = int(ceil(numBits))
 
 	print "#numItems\tbfFP\tnumHashes\tnumBits"


### PR DESCRIPTION
Because `numHashFuncs` is an integer,

```python
log(1-(fpRate)**(1/numHashFuncs))
```
will become (e.g., for `numHashFuncs=2`) :
```python
log(1-(fpRate)**(1/2))
log(1-(fpRate)**0)
log(1-1)
log(0)
```
Which then throws a domain error.